### PR TITLE
feat: parse equipment details from stat blocks

### DIFF
--- a/src/services/optolith/__tests__/statBlockParser.spec.ts
+++ b/src/services/optolith/__tests__/statBlockParser.spec.ts
@@ -21,6 +21,24 @@ describe("parseStatBlock", () => {
     expect(result.model.talents).toContainEqual({ name: "Betören", value: 10 });
     expect(result.model.weapons).toHaveLength(2);
     expect(result.warnings).toHaveLength(0);
+
+    const rapier = result.model.weapons.find(
+      (weapon) => weapon.name === "Rapier",
+    );
+    expect(rapier?.attack).toBe(18);
+    expect(rapier?.parry).toBe(10);
+    expect(rapier?.range).toBe("mittel");
+    expect(rapier?.rawInput).toContain("Rapier");
+
+    const whip = result.model.weapons.find(
+      (weapon) => weapon.name === "Entdeckerpeitsche",
+    );
+    expect(whip?.range).toBe("lang");
+    expect(whip?.attack).toBe(16);
+
+    expect(result.model.armor?.rs).toBe(1);
+    expect(result.model.armor?.be).toBe(0);
+    expect(result.model.armor?.description).toBe("schwere Kleidung");
   });
 
   it("classifies combined advantages/disadvantages correctly", async () => {
@@ -37,6 +55,13 @@ describe("parseStatBlock", () => {
       result.model.weapons.find((weapon) => weapon.name === "Wurfspeer")
         ?.category,
     ).toBe("ranged");
+
+    const unarmed = result.model.weapons.find(
+      (weapon) => weapon.name === "Waffenlos",
+    );
+    expect(unarmed?.category).toBe("unarmed");
+    expect(result.model.armor?.rs).toBe(0);
+    expect(result.model.armor?.description).toBeNull();
   });
 
   it("normalizes wrapped talents for Gerion sample", async () => {
@@ -73,6 +98,12 @@ describe("parseStatBlock", () => {
     expect(distanceAbility).toBeDefined();
     expect(distanceAbility).toContain("Tauchspeer");
     expect(distanceAbility).not.toMatch(/AKO/i);
+
+    const blowpipe = result.model.weapons.find(
+      (weapon) => weapon.name === "Blasrohr",
+    );
+    expect(blowpipe?.rangedAttack).toBe(14);
+    expect(blowpipe?.damage).toBe("1W3+1(+Gift*)");
   });
 
   it("captures liturgies and handles explicit none markers", async () => {
@@ -98,5 +129,9 @@ describe("parseStatBlock", () => {
       (talent) => talent.name === "Sinnesschärfe",
     );
     expect(senseTalent?.value).toBe(8);
+
+    expect(result.model.armor?.rs).toBe(2);
+    expect(result.model.armor?.be).toBe(0);
+    expect(result.model.armor?.description).toBe("Bastrüstung");
   });
 });

--- a/src/types/optolith/stat-block.ts
+++ b/src/types/optolith/stat-block.ts
@@ -33,6 +33,15 @@ export interface WeaponStats {
   readonly reach?: string | null;
   readonly notes?: string | null;
   readonly raw: Record<string, string>;
+  readonly rawInput: string;
+}
+
+export interface ArmorStats {
+  readonly rs: number | null;
+  readonly be: number | null;
+  readonly description: string | null;
+  readonly notes: string | null;
+  readonly raw: string;
 }
 
 export interface TalentRating {
@@ -55,7 +64,7 @@ export interface ParsedStatBlock {
   readonly name: string;
   readonly attributes: AttributeSet;
   readonly pools: ResourcePools;
-  readonly armor?: string;
+  readonly armor?: ArmorStats | null;
   readonly actions?: number | null;
   readonly weapons: readonly WeaponStats[];
   readonly advantages: readonly string[];


### PR DESCRIPTION
## Summary
- extend parser to capture detailed weapon stats and RS/BE armor information
- add ArmorStats type plus weapon raw input for downstream resolver work
- cover equipment parsing with updated unit tests across representative samples

## Testing
- npm run lint
- npm run typecheck
- npm run test:unit