### PR TITLE
feat: surface equipment data across Optolith export and UI

### DIFF
--- a/planning/runs/2025-10-16T12-00-00-dsa5-optolith-converter/sample-analysis-2025-11-06T08-27-27.md
+++ b/planning/runs/2025-10-16T12-00-00-dsa5-optolith-converter/sample-analysis-2025-11-06T08-27-27.md
@@ -1,0 +1,1014 @@
+# Optolith Sample QA — 2025-10-16
+
+## Notia Botero-Montez
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Waffe "Entdeckerpeitsche" wurde als "Fuhrmannspeitsche" interpretiert (Schlüsselwort "peitsche").
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] weapons: Waffe "Entdeckerpeitsche" wurde als "Fuhrmannspeitsche" interpretiert (Schlüsselwort "peitsche").
+
+## Gerion Mtoto
+
+### Parser Warnings
+- talents: Abschnitt "talents" nicht gefunden.
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Parser] talents: Abschnitt "talents" nicht gefunden.
+
+## Nepi-Luhan
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Waffe "Tauchspeer" wurde als "Speer" interpretiert (Schlüsselwort "speer").
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] weapons: Waffe "Tauchspeer" wurde als "Speer" interpretiert (Schlüsselwort "speer").
+
+## Stammeskriegerin der Napewanha
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- armor: Eintrag "Bastrüstung" konnte im Abschnitt armor nicht aufgelöst werden.
+
+### Unresolved References
+- **armor**: Bastrüstung
+
+### Exporter Warnings
+- [Resolver] armor: Eintrag "Bastrüstung" konnte im Abschnitt armor nicht aufgelöst werden.
+- [Resolver] armor: unverarbeitet "Bastrüstung"
+- [Exporter] armor: Rüstung "Bastrüstung" konnte nicht exportiert werden (keine Zuordnung).
+
+## Schamane
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- liturgies: Eintrag "Hauch des Elements" konnte im Abschnitt liturgies nicht aufgelöst werden.
+
+### Unresolved References
+- **liturgies**: Hauch des Elements
+
+### Exporter Warnings
+- [Resolver] liturgies: Eintrag "Hauch des Elements" konnte im Abschnitt liturgies nicht aufgelöst werden.
+- [Resolver] liturgies: unverarbeitet "Hauch des Elements"
+
+## Achaz-Krieger
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- armor: Eintrag "RS 1 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+
+### Unresolved References
+- **armor**: RS 1 / BE 0
+
+### Exporter Warnings
+- [Resolver] armor: Eintrag "RS 1 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- [Resolver] armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+- [Resolver] armor: unverarbeitet "RS 1 / BE 0"
+- [Exporter] armor: Rüstung "1/0" konnte nicht exportiert werden (keine Zuordnung).
+
+## Katka-Iok und ihre Animisten
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Waffe "Epharit-Schild" wurde als "Holzschild" interpretiert (Schlüsselwort "schild").
+- weapons: Waffe "Epharit-Schwert" wurde als "Langschwert" interpretiert (Schlüsselwort "schwert").
+- weapons: Waffe "Epharit-Speer" wurde als "Speer" interpretiert (Teilbegriff "Speer").
+- armor: Eintrag "RS 6 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+
+### Unresolved References
+- **armor**: RS 6 / BE 0
+
+### Exporter Warnings
+- [Resolver] weapons: Waffe "Epharit-Schild" wurde als "Holzschild" interpretiert (Schlüsselwort "schild").
+- [Resolver] weapons: Waffe "Epharit-Schwert" wurde als "Langschwert" interpretiert (Schlüsselwort "schwert").
+- [Resolver] weapons: Waffe "Epharit-Speer" wurde als "Speer" interpretiert (Teilbegriff "Speer").
+- [Resolver] armor: Eintrag "RS 6 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- [Resolver] armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+- [Resolver] armor: unverarbeitet "RS 6 / BE 0"
+- [Exporter] armor: Rüstung "6/0" konnte nicht exportiert werden (keine Zuordnung).
+
+## Maru-Kriegerin
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Eintrag "Biss" konnte im Abschnitt weapons nicht aufgelöst werden.
+- weapons: Eintrag "Schwanz" konnte im Abschnitt weapons nicht aufgelöst werden.
+- weapons: Waffe "Maru-Säbel*" wurde als "Säbel" interpretiert (Teilbegriff "Säbel*").
+- armor: Eintrag "RS 4 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+
+### Unresolved References
+- **weapons**: Biss, Schwanz
+- **armor**: RS 4 / BE 0
+
+### Exporter Warnings
+- [Resolver] weapons: Eintrag "Biss" konnte im Abschnitt weapons nicht aufgelöst werden.
+- [Resolver] weapons: Eintrag "Schwanz" konnte im Abschnitt weapons nicht aufgelöst werden.
+- [Resolver] weapons: Waffe "Maru-Säbel*" wurde als "Säbel" interpretiert (Teilbegriff "Säbel*").
+- [Resolver] armor: Eintrag "RS 4 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- [Resolver] armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+- [Resolver] weapons: unverarbeitet "Biss"
+- [Resolver] weapons: unverarbeitet "Schwanz"
+- [Resolver] armor: unverarbeitet "RS 4 / BE 0"
+- [Exporter] weapons: Waffe "Biss" konnte nicht exportiert werden (keine Zuordnung).
+- [Exporter] weapons: Waffe "Schwanz" konnte nicht exportiert werden (keine Zuordnung).
+- [Exporter] armor: Rüstung "4/0" konnte nicht exportiert werden (keine Zuordnung).
+
+## Jupopu-Lokan
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Waffe "Epharit-Schild" wurde als "Holzschild" interpretiert (Schlüsselwort "schild").
+- weapons: Waffe "Epharit-Speer" wurde als "Speer" interpretiert (Teilbegriff "Speer").
+- armor: Eintrag "RS 6 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+
+### Unresolved References
+- **armor**: RS 6 / BE 0
+
+### Exporter Warnings
+- [Resolver] weapons: Waffe "Epharit-Schild" wurde als "Holzschild" interpretiert (Schlüsselwort "schild").
+- [Resolver] weapons: Waffe "Epharit-Speer" wurde als "Speer" interpretiert (Teilbegriff "Speer").
+- [Resolver] armor: Eintrag "RS 6 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- [Resolver] armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+- [Resolver] armor: unverarbeitet "RS 6 / BE 0"
+- [Exporter] armor: Rüstung "6/0" konnte nicht exportiert werden (keine Zuordnung).
+
+## Chr’ho
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Eintrag "Biss" konnte im Abschnitt weapons nicht aufgelöst werden.
+- weapons: Eintrag "Schwanz" konnte im Abschnitt weapons nicht aufgelöst werden.
+- weapons: Waffe "Maru-Säbel*" wurde als "Säbel" interpretiert (Teilbegriff "Säbel*").
+- armor: Eintrag "RS 4 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+
+### Unresolved References
+- **weapons**: Biss, Schwanz
+- **armor**: RS 4 / BE 0
+
+### Exporter Warnings
+- [Resolver] weapons: Eintrag "Biss" konnte im Abschnitt weapons nicht aufgelöst werden.
+- [Resolver] weapons: Eintrag "Schwanz" konnte im Abschnitt weapons nicht aufgelöst werden.
+- [Resolver] weapons: Waffe "Maru-Säbel*" wurde als "Säbel" interpretiert (Teilbegriff "Säbel*").
+- [Resolver] armor: Eintrag "RS 4 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- [Resolver] armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+- [Resolver] weapons: unverarbeitet "Biss"
+- [Resolver] weapons: unverarbeitet "Schwanz"
+- [Resolver] armor: unverarbeitet "RS 4 / BE 0"
+- [Exporter] weapons: Waffe "Biss" konnte nicht exportiert werden (keine Zuordnung).
+- [Exporter] weapons: Waffe "Schwanz" konnte nicht exportiert werden (keine Zuordnung).
+- [Exporter] armor: Rüstung "4/0" konnte nicht exportiert werden (keine Zuordnung).
+
+## Djer’kem (Kemi-Späher)
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Verteidiger von Menehet
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- advantages: Eintrag "keine (ein paar Bewohner können die SF Finte I beherrschen)" konnte im Abschnitt advantages nicht aufgelöst werden.
+- disadvantages: Eintrag "keine (ein paar Bewohner können die SF Finte I beherrschen)" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+
+### Unresolved References
+- **advantages**: keine (ein paar Bewohner können die SF Finte I beherrschen)
+- **disadvantages**: keine (ein paar Bewohner können die SF Finte I beherrschen)
+
+### Exporter Warnings
+- [Resolver] advantages: Eintrag "keine (ein paar Bewohner können die SF Finte I beherrschen)" konnte im Abschnitt advantages nicht aufgelöst werden.
+- [Resolver] disadvantages: Eintrag "keine (ein paar Bewohner können die SF Finte I beherrschen)" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+- [Resolver] advantages: unverarbeitet "keine (ein paar Bewohner können die SF Finte I beherrschen)"
+- [Resolver] disadvantages: unverarbeitet "keine (ein paar Bewohner können die SF Finte I beherrschen)"
+
+## Faedred
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Stammeskrieger der Keke-Wanaq
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Stammeskrieger der Achaz
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- armor: Eintrag "RS 1 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+
+### Unresolved References
+- **armor**: RS 1 / BE 0
+
+### Exporter Warnings
+- [Resolver] armor: Eintrag "RS 1 / BE 0" konnte im Abschnitt armor nicht aufgelöst werden.
+- [Resolver] armor: RS/BE-Angabe ohne Beschreibung (möglicherweise natürlicher Rüstungsschutz).
+- [Resolver] armor: unverarbeitet "RS 1 / BE 0"
+- [Exporter] armor: Rüstung "1/0" konnte nicht exportiert werden (keine Zuordnung).
+
+## Milizionär
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Regulario
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Laguana-Ordensritter
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Kopfgeldjäger
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- talents: Talent "Fährtensuchern" wurde als "Fährtensuchen" interpretiert (Schreibweise korrigiert).
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] talents: Talent "Fährtensuchern" wurde als "Fährtensuchen" interpretiert (Schreibweise korrigiert).
+
+## Stammeskrieger der Tschopukikuha
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Deserteure
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Brekker-Bande
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Thuan de Vries
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Die Immanspieler und ihre Anhänger
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Odina Hortemann
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Arn Knokenbreeker
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- equipment: Ausrüstungseintrag "Immanschläger, den er als Knüppel nutzt" wurde als "Knüppel" interpretiert (Teilbegriff "Knüppel").
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] equipment: Ausrüstungseintrag "Immanschläger, den er als Knüppel nutzt" wurde als "Knüppel" interpretiert (Teilbegriff "Knüppel").
+
+## Beispielhafte Anleger
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- advantages: Eintrag "individuell" konnte im Abschnitt advantages nicht aufgelöst werden.
+- advantages: Eintrag "etwa Personlichkeitsschwächen (Eitelkeit)" konnte im Abschnitt advantages nicht aufgelöst werden.
+- disadvantages: Eintrag "individuell" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+- disadvantages: Eintrag "etwa Personlichkeitsschwächen (Eitelkeit)" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+
+### Unresolved References
+- **advantages**: individuell, etwa Personlichkeitsschwächen (Eitelkeit)
+- **disadvantages**: individuell, etwa Personlichkeitsschwächen (Eitelkeit)
+
+### Exporter Warnings
+- [Resolver] advantages: Eintrag "individuell" konnte im Abschnitt advantages nicht aufgelöst werden.
+- [Resolver] advantages: Eintrag "etwa Personlichkeitsschwächen (Eitelkeit)" konnte im Abschnitt advantages nicht aufgelöst werden.
+- [Resolver] disadvantages: Eintrag "individuell" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+- [Resolver] disadvantages: Eintrag "etwa Personlichkeitsschwächen (Eitelkeit)" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+- [Resolver] advantages: unverarbeitet "individuell"
+- [Resolver] advantages: unverarbeitet "etwa Personlichkeitsschwächen (Eitelkeit)"
+- [Resolver] disadvantages: unverarbeitet "individuell"
+- [Resolver] disadvantages: unverarbeitet "etwa Personlichkeitsschwächen (Eitelkeit)"
+
+## Bewohner Frisovs
+
+### Parser Warnings
+- talents: Talent konnte nicht interpretiert werden: "ein Talent, das er für seinen Beruf nutzt 10 (etwa Fischen & Angeln, Tierkunde, Fährtensuchen oder ein Handwerkstalent)"
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Parser] talents: Talent konnte nicht interpretiert werden: "ein Talent, das er für seinen Beruf nutzt 10 (etwa Fischen & Angeln, Tierkunde, Fährtensuchen oder ein Handwerkstalent)"
+
+## Wigbald Isgart von Baliho
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- equipment: Ausrüstungseintrag "Geweihter Rondrakamm Isgart" wurde als "Rondrakamm" interpretiert (Teilbegriff "Rondrakamm").
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] equipment: Ausrüstungseintrag "Geweihter Rondrakamm Isgart" wurde als "Rondrakamm" interpretiert (Teilbegriff "Rondrakamm").
+
+## Quenia Goldwige vom Berg
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- equipment: Eintrag "Wintertaugliche Robe" konnte im Abschnitt equipment nicht aufgelöst werden.
+
+### Unresolved References
+- **equipment**: Wintertaugliche Robe
+
+### Exporter Warnings
+- [Resolver] equipment: Eintrag "Wintertaugliche Robe" konnte im Abschnitt equipment nicht aufgelöst werden.
+- [Resolver] equipment: unverarbeitet "Wintertaugliche Robe"
+
+## Sonnenlegionär
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Bannstrahler
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Mrom
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Yeti-Kämpfer
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## ungavik, die Vielfache Zunge
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- specialAbilities: Eintrag "• Flugangriff (Wanst) • Klammerangriff (Tentakel, Dem Wesen muss eine AT mit seinem Fangarm gelingen. Kann der Gegner sich nicht verteidigen, hält der Angreifer ihn fest. Solange der Gegner festgehalten wird, leidet er unter den Status Fixiert und Eingeengt. Ab der nächsten KR muss das Wesen keine AT mehr würfeln, sondern erzeugt durch Quetschen SP in Höhe der ausgewürfelten TP des Angriffs. Alternativ kann das Wesen 1 Aktion aufwenden, um das Opfer zu seinem Maul zu heben. In der folgenden KR kann das Wesen dann zubeißen. Diese Biss-Attacke gelingt gegen einen festgehaltenen Gegner. Die Verteidigung des Angreifers sinkt für den Rest der KR, in welcher der Biss stattfindet, auf 0. Der Klammergriff kann nur gegen Gegner kleinerer Größenkategorien eingesetzt werden. Um sich aus dem Klammergriff zu lösen, ist eine gelungene Vergleichsprobe auf Kraftakt (Ziehen & Zerren) nötig. Mittels einer freien Aktion kann der Klammernde den Gehaltenen loslassen. Sollte der Klammernde sein Opfer angehoben haben, stürzt es und erleidet den Status Liegend, sofern ihm nicht eine Probe auf Körperbeherrschung (Kampfmanöver) gelingt. Der Angriff ist um 4 erschwert.) • Mächtiger Schlag (Wanst, Tentakel, Hals) • Tentakelschwung (Tentakel, Hals, Ist das angreifende Wesen mindestens eine Größenkategorie größer als seine Ziele, kann es mit einem Tentakelschwung mehrere Gegner zu Fall bringen. Diesem Angriff kann man nur ausweichen. Ist die Verteidigung misslungen, stürzt der Gegner und erleidet den Status Liegend. Durch den Fall erleidet man 1W3 SP. Ein solcher Angriff kann nur gegen Ziele vor dem angreifenden Wesen ausgeführt werden. Die Attacke ist um 2 pro Ziel erschwert.) • Unterwasserkampf (Erschwernisse im Kampf unter Wassergelten nicht (siehe Regelwerk Seite 239). • Verbeißen (Maul)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: • Flugangriff (Wanst) • Klammerangriff (Tentakel, Dem Wesen muss eine AT mit seinem Fangarm gelingen. Kann der Gegner sich nicht verteidigen, hält der Angreifer ihn fest. Solange der Gegner festgehalten wird, leidet er unter den Status Fixiert und Eingeengt. Ab der nächsten KR muss das Wesen keine AT mehr würfeln, sondern erzeugt durch Quetschen SP in Höhe der ausgewürfelten TP des Angriffs. Alternativ kann das Wesen 1 Aktion aufwenden, um das Opfer zu seinem Maul zu heben. In der folgenden KR kann das Wesen dann zubeißen. Diese Biss-Attacke gelingt gegen einen festgehaltenen Gegner. Die Verteidigung des Angreifers sinkt für den Rest der KR, in welcher der Biss stattfindet, auf 0. Der Klammergriff kann nur gegen Gegner kleinerer Größenkategorien eingesetzt werden. Um sich aus dem Klammergriff zu lösen, ist eine gelungene Vergleichsprobe auf Kraftakt (Ziehen & Zerren) nötig. Mittels einer freien Aktion kann der Klammernde den Gehaltenen loslassen. Sollte der Klammernde sein Opfer angehoben haben, stürzt es und erleidet den Status Liegend, sofern ihm nicht eine Probe auf Körperbeherrschung (Kampfmanöver) gelingt. Der Angriff ist um 4 erschwert.) • Mächtiger Schlag (Wanst, Tentakel, Hals) • Tentakelschwung (Tentakel, Hals, Ist das angreifende Wesen mindestens eine Größenkategorie größer als seine Ziele, kann es mit einem Tentakelschwung mehrere Gegner zu Fall bringen. Diesem Angriff kann man nur ausweichen. Ist die Verteidigung misslungen, stürzt der Gegner und erleidet den Status Liegend. Durch den Fall erleidet man 1W3 SP. Ein solcher Angriff kann nur gegen Ziele vor dem angreifenden Wesen ausgeführt werden. Die Attacke ist um 2 pro Ziel erschwert.) • Unterwasserkampf (Erschwernisse im Kampf unter Wassergelten nicht (siehe Regelwerk Seite 239). • Verbeißen (Maul)
+
+### Exporter Warnings
+- [Resolver] specialAbilities: Eintrag "• Flugangriff (Wanst) • Klammerangriff (Tentakel, Dem Wesen muss eine AT mit seinem Fangarm gelingen. Kann der Gegner sich nicht verteidigen, hält der Angreifer ihn fest. Solange der Gegner festgehalten wird, leidet er unter den Status Fixiert und Eingeengt. Ab der nächsten KR muss das Wesen keine AT mehr würfeln, sondern erzeugt durch Quetschen SP in Höhe der ausgewürfelten TP des Angriffs. Alternativ kann das Wesen 1 Aktion aufwenden, um das Opfer zu seinem Maul zu heben. In der folgenden KR kann das Wesen dann zubeißen. Diese Biss-Attacke gelingt gegen einen festgehaltenen Gegner. Die Verteidigung des Angreifers sinkt für den Rest der KR, in welcher der Biss stattfindet, auf 0. Der Klammergriff kann nur gegen Gegner kleinerer Größenkategorien eingesetzt werden. Um sich aus dem Klammergriff zu lösen, ist eine gelungene Vergleichsprobe auf Kraftakt (Ziehen & Zerren) nötig. Mittels einer freien Aktion kann der Klammernde den Gehaltenen loslassen. Sollte der Klammernde sein Opfer angehoben haben, stürzt es und erleidet den Status Liegend, sofern ihm nicht eine Probe auf Körperbeherrschung (Kampfmanöver) gelingt. Der Angriff ist um 4 erschwert.) • Mächtiger Schlag (Wanst, Tentakel, Hals) • Tentakelschwung (Tentakel, Hals, Ist das angreifende Wesen mindestens eine Größenkategorie größer als seine Ziele, kann es mit einem Tentakelschwung mehrere Gegner zu Fall bringen. Diesem Angriff kann man nur ausweichen. Ist die Verteidigung misslungen, stürzt der Gegner und erleidet den Status Liegend. Durch den Fall erleidet man 1W3 SP. Ein solcher Angriff kann nur gegen Ziele vor dem angreifenden Wesen ausgeführt werden. Die Attacke ist um 2 pro Ziel erschwert.) • Unterwasserkampf (Erschwernisse im Kampf unter Wassergelten nicht (siehe Regelwerk Seite 239). • Verbeißen (Maul)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "• Flugangriff (Wanst) • Klammerangriff (Tentakel, Dem Wesen muss eine AT mit seinem Fangarm gelingen. Kann der Gegner sich nicht verteidigen, hält der Angreifer ihn fest. Solange der Gegner festgehalten wird, leidet er unter den Status Fixiert und Eingeengt. Ab der nächsten KR muss das Wesen keine AT mehr würfeln, sondern erzeugt durch Quetschen SP in Höhe der ausgewürfelten TP des Angriffs. Alternativ kann das Wesen 1 Aktion aufwenden, um das Opfer zu seinem Maul zu heben. In der folgenden KR kann das Wesen dann zubeißen. Diese Biss-Attacke gelingt gegen einen festgehaltenen Gegner. Die Verteidigung des Angreifers sinkt für den Rest der KR, in welcher der Biss stattfindet, auf 0. Der Klammergriff kann nur gegen Gegner kleinerer Größenkategorien eingesetzt werden. Um sich aus dem Klammergriff zu lösen, ist eine gelungene Vergleichsprobe auf Kraftakt (Ziehen & Zerren) nötig. Mittels einer freien Aktion kann der Klammernde den Gehaltenen loslassen. Sollte der Klammernde sein Opfer angehoben haben, stürzt es und erleidet den Status Liegend, sofern ihm nicht eine Probe auf Körperbeherrschung (Kampfmanöver) gelingt. Der Angriff ist um 4 erschwert.) • Mächtiger Schlag (Wanst, Tentakel, Hals) • Tentakelschwung (Tentakel, Hals, Ist das angreifende Wesen mindestens eine Größenkategorie größer als seine Ziele, kann es mit einem Tentakelschwung mehrere Gegner zu Fall bringen. Diesem Angriff kann man nur ausweichen. Ist die Verteidigung misslungen, stürzt der Gegner und erleidet den Status Liegend. Durch den Fall erleidet man 1W3 SP. Ein solcher Angriff kann nur gegen Ziele vor dem angreifenden Wesen ausgeführt werden. Die Attacke ist um 2 pro Ziel erschwert.) • Unterwasserkampf (Erschwernisse im Kampf unter Wassergelten nicht (siehe Regelwerk Seite 239). • Verbeißen (Maul)"
+
+## Phanta
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- equipment: Eintrag "Anaurak" konnte im Abschnitt equipment nicht aufgelöst werden.
+- equipment: Ausrüstungseintrag "Speere" wurde als "Speer" interpretiert (Teilbegriff "Speer").
+- equipment: Ausrüstungseintrag "Wurfkeulen" wurde als "Wurfkeule" interpretiert (Teilbegriff "Wurfkeule").
+
+### Unresolved References
+- **equipment**: Anaurak
+
+### Exporter Warnings
+- [Resolver] equipment: Eintrag "Anaurak" konnte im Abschnitt equipment nicht aufgelöst werden.
+- [Resolver] equipment: Ausrüstungseintrag "Speere" wurde als "Speer" interpretiert (Teilbegriff "Speer").
+- [Resolver] equipment: Ausrüstungseintrag "Wurfkeulen" wurde als "Wurfkeule" interpretiert (Teilbegriff "Wurfkeule").
+- [Resolver] equipment: unverarbeitet "Anaurak"
+
+## Nivese
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Khydaka Eisblüte
+
+### Parser Warnings
+- spells: Wert für spells konnte nicht ermittelt werden: "Schlangenhände"
+- spells: Wert für spells konnte nicht ermittelt werden: "Trocken"
+
+### Resolver Warnings
+- disadvantages: Eintrag "Metallempfindlich" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+- specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- spells: Eintrag "Schlangenhände" konnte im Abschnitt spells nicht aufgelöst werden.
+- spells: Eintrag "Trocken" konnte im Abschnitt spells nicht aufgelöst werden.
+
+### Unresolved References
+- **disadvantages**: Metallempfindlich
+- **specialAbilities**: Tradition (Nachtalben)
+- **spells**: Schlangenhände, Trocken
+
+### Exporter Warnings
+- [Parser] spells: Wert für spells konnte nicht ermittelt werden: "Schlangenhände"
+- [Parser] spells: Wert für spells konnte nicht ermittelt werden: "Trocken"
+- [Resolver] disadvantages: Eintrag "Metallempfindlich" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+- [Resolver] specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] spells: Eintrag "Schlangenhände" konnte im Abschnitt spells nicht aufgelöst werden.
+- [Resolver] spells: Eintrag "Trocken" konnte im Abschnitt spells nicht aufgelöst werden.
+- [Resolver] disadvantages: unverarbeitet "Metallempfindlich"
+- [Resolver] specialAbilities: unverarbeitet "Tradition (Nachtalben)"
+- [Resolver] spells: unverarbeitet "Schlangenhände"
+- [Resolver] spells: unverarbeitet "Trocken"
+
+## Ryosho Lebensfänger
+
+### Parser Warnings
+- spells: Wert für spells konnte nicht ermittelt werden: "Feuerfinger"
+
+### Resolver Warnings
+- disadvantages: Eintrag "Metallempfindlich" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+- specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- spells: Eintrag "Feuerfinger" konnte im Abschnitt spells nicht aufgelöst werden.
+- equipment: Ausrüstungseintrag "Shakagra-Schwerter" wurde als "Langschwert" interpretiert (Schlüsselwort "schwert").
+- equipment: Ausrüstungseintrag "leichte Shakagra-Plattenrüstung" wurde als "Plattenrüstung" interpretiert (Teilbegriff "Plattenrüstung").
+
+### Unresolved References
+- **disadvantages**: Metallempfindlich
+- **specialAbilities**: Tradition (Nachtalben)
+- **spells**: Feuerfinger
+
+### Exporter Warnings
+- [Parser] spells: Wert für spells konnte nicht ermittelt werden: "Feuerfinger"
+- [Resolver] disadvantages: Eintrag "Metallempfindlich" konnte im Abschnitt disadvantages nicht aufgelöst werden.
+- [Resolver] specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] spells: Eintrag "Feuerfinger" konnte im Abschnitt spells nicht aufgelöst werden.
+- [Resolver] equipment: Ausrüstungseintrag "Shakagra-Schwerter" wurde als "Langschwert" interpretiert (Schlüsselwort "schwert").
+- [Resolver] equipment: Ausrüstungseintrag "leichte Shakagra-Plattenrüstung" wurde als "Plattenrüstung" interpretiert (Teilbegriff "Plattenrüstung").
+- [Resolver] disadvantages: unverarbeitet "Metallempfindlich"
+- [Resolver] specialAbilities: unverarbeitet "Tradition (Nachtalben)"
+- [Resolver] spells: unverarbeitet "Feuerfinger"
+
+## Krakenmolch
+
+### Parser Warnings
+- talents: Talent konnte nicht interpretiert werden: "Willenskraft 4 (15/13/8)"
+
+### Resolver Warnings
+- specialAbilities: Eintrag "• Klammergriff (Fangarm, kann der Gegner sich nicht erfolgreich verteidigen, hält der Krakenmolch ihn fest. Solange der Gegner festgehalten wird, leidet er unter den Status Fixiert und Eingeengt. Ab der nächsten KR muss der Krakenmolch keine AT mehr würfeln, sondern erzeugt durch Quetschen SP in Höhe der ausgewürfelten TP des Angriffs. Alternativ kann das Wesen 1 Aktion aufwenden, um das Opfer zu seinem Maul zu heben. In der folgenden KR kann er dann zubeißen. Diese Attacke gelingt automatisch. Die Verteidigung des Angreifers sinkt während des Rests der KR, in der der Biss stattfindet, auf 0. Der Klammergriff kann nur gegen Gegner kleinerer Größenkategorien verwendet werden. Um sich aus dem Klammergriff zu lösen, ist eine gelungene Vergleichsprobe auf Kraftakt (Ziehen & Zerren) nötig. Der Haltegriff kann nur gegen Gegner kleinerer Größenkategorien verwendet werden. Mittels einer freien Aktion kann der Krakenmolch den Gehaltenen loslassen. Sollte der Krakenmolch sein Opfer angehoben haben, erleidet es daraufhin den Status Liegend, sofern ihm nicht eine Probe auf Körperbeherrschung (Kampfmanöver) gelingt.) • Mächtiger Schlag (Fangarm, bei erfolgreichem Angriff müssen Gegner der Größenkategorie mittel und kleiner eine Probe auf Kraftakt erschwert um 8 bestehen, sofern sie nicht ausgewichen sind, ansonsten erhalten sie den Status Liegend) • Tentakelschwung (Fangarm, ist der Krakenmolch mindestens eine Größenkategorie größer als seine Ziele, kann er mit einem Tentakelschwung mehrere Ziele zu Fall bringen. Gegen diesen Angriff kann man nur ausweichen. Ist die Verteidigung misslungen, stürzt der Gegner und erleidet den Status Liegend. Durch den Fall erleidet man 1W3 SP. Ein solcher Angriff kann nur gegen Ziele neben oder vor dem angreifenden Wesen ausgeführt werden. Die Attacke ist um 2 pro Ziel erschwert.) • Verbeißen (Biss, der Krakenmolch führt einen Biss-Angriff aus. Kann der gelungene Angriff nicht verteidigt werden, so hat er sich festgebissen. In den nachfolgenden KR gelingt die Biss-Attacke automatisch, ohne dass der Meister würfeln muss. Jede KR richtet der Verbeißen-Angriff+1 TP an (in der ersten KR noch keinen zusätzlichen TP, in der 2. KR+1TP, in der 3. KR+2 TP usw.). Die TP werden wie üblich ausgewürfelt. Der Gegner erhält den Status Fixiert. Die Verteidigung des Molches sinkt, während er beißt, auf 0. Der Krakenmolch kann am Ende einer KR entscheiden loszulassen. Dieser Angriff ist um 2 erschwert.)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: • Klammergriff (Fangarm, kann der Gegner sich nicht erfolgreich verteidigen, hält der Krakenmolch ihn fest. Solange der Gegner festgehalten wird, leidet er unter den Status Fixiert und Eingeengt. Ab der nächsten KR muss der Krakenmolch keine AT mehr würfeln, sondern erzeugt durch Quetschen SP in Höhe der ausgewürfelten TP des Angriffs. Alternativ kann das Wesen 1 Aktion aufwenden, um das Opfer zu seinem Maul zu heben. In der folgenden KR kann er dann zubeißen. Diese Attacke gelingt automatisch. Die Verteidigung des Angreifers sinkt während des Rests der KR, in der der Biss stattfindet, auf 0. Der Klammergriff kann nur gegen Gegner kleinerer Größenkategorien verwendet werden. Um sich aus dem Klammergriff zu lösen, ist eine gelungene Vergleichsprobe auf Kraftakt (Ziehen & Zerren) nötig. Der Haltegriff kann nur gegen Gegner kleinerer Größenkategorien verwendet werden. Mittels einer freien Aktion kann der Krakenmolch den Gehaltenen loslassen. Sollte der Krakenmolch sein Opfer angehoben haben, erleidet es daraufhin den Status Liegend, sofern ihm nicht eine Probe auf Körperbeherrschung (Kampfmanöver) gelingt.) • Mächtiger Schlag (Fangarm, bei erfolgreichem Angriff müssen Gegner der Größenkategorie mittel und kleiner eine Probe auf Kraftakt erschwert um 8 bestehen, sofern sie nicht ausgewichen sind, ansonsten erhalten sie den Status Liegend) • Tentakelschwung (Fangarm, ist der Krakenmolch mindestens eine Größenkategorie größer als seine Ziele, kann er mit einem Tentakelschwung mehrere Ziele zu Fall bringen. Gegen diesen Angriff kann man nur ausweichen. Ist die Verteidigung misslungen, stürzt der Gegner und erleidet den Status Liegend. Durch den Fall erleidet man 1W3 SP. Ein solcher Angriff kann nur gegen Ziele neben oder vor dem angreifenden Wesen ausgeführt werden. Die Attacke ist um 2 pro Ziel erschwert.) • Verbeißen (Biss, der Krakenmolch führt einen Biss-Angriff aus. Kann der gelungene Angriff nicht verteidigt werden, so hat er sich festgebissen. In den nachfolgenden KR gelingt die Biss-Attacke automatisch, ohne dass der Meister würfeln muss. Jede KR richtet der Verbeißen-Angriff+1 TP an (in der ersten KR noch keinen zusätzlichen TP, in der 2. KR+1TP, in der 3. KR+2 TP usw.). Die TP werden wie üblich ausgewürfelt. Der Gegner erhält den Status Fixiert. Die Verteidigung des Molches sinkt, während er beißt, auf 0. Der Krakenmolch kann am Ende einer KR entscheiden loszulassen. Dieser Angriff ist um 2 erschwert.)
+
+### Exporter Warnings
+- [Parser] talents: Talent konnte nicht interpretiert werden: "Willenskraft 4 (15/13/8)"
+- [Resolver] specialAbilities: Eintrag "• Klammergriff (Fangarm, kann der Gegner sich nicht erfolgreich verteidigen, hält der Krakenmolch ihn fest. Solange der Gegner festgehalten wird, leidet er unter den Status Fixiert und Eingeengt. Ab der nächsten KR muss der Krakenmolch keine AT mehr würfeln, sondern erzeugt durch Quetschen SP in Höhe der ausgewürfelten TP des Angriffs. Alternativ kann das Wesen 1 Aktion aufwenden, um das Opfer zu seinem Maul zu heben. In der folgenden KR kann er dann zubeißen. Diese Attacke gelingt automatisch. Die Verteidigung des Angreifers sinkt während des Rests der KR, in der der Biss stattfindet, auf 0. Der Klammergriff kann nur gegen Gegner kleinerer Größenkategorien verwendet werden. Um sich aus dem Klammergriff zu lösen, ist eine gelungene Vergleichsprobe auf Kraftakt (Ziehen & Zerren) nötig. Der Haltegriff kann nur gegen Gegner kleinerer Größenkategorien verwendet werden. Mittels einer freien Aktion kann der Krakenmolch den Gehaltenen loslassen. Sollte der Krakenmolch sein Opfer angehoben haben, erleidet es daraufhin den Status Liegend, sofern ihm nicht eine Probe auf Körperbeherrschung (Kampfmanöver) gelingt.) • Mächtiger Schlag (Fangarm, bei erfolgreichem Angriff müssen Gegner der Größenkategorie mittel und kleiner eine Probe auf Kraftakt erschwert um 8 bestehen, sofern sie nicht ausgewichen sind, ansonsten erhalten sie den Status Liegend) • Tentakelschwung (Fangarm, ist der Krakenmolch mindestens eine Größenkategorie größer als seine Ziele, kann er mit einem Tentakelschwung mehrere Ziele zu Fall bringen. Gegen diesen Angriff kann man nur ausweichen. Ist die Verteidigung misslungen, stürzt der Gegner und erleidet den Status Liegend. Durch den Fall erleidet man 1W3 SP. Ein solcher Angriff kann nur gegen Ziele neben oder vor dem angreifenden Wesen ausgeführt werden. Die Attacke ist um 2 pro Ziel erschwert.) • Verbeißen (Biss, der Krakenmolch führt einen Biss-Angriff aus. Kann der gelungene Angriff nicht verteidigt werden, so hat er sich festgebissen. In den nachfolgenden KR gelingt die Biss-Attacke automatisch, ohne dass der Meister würfeln muss. Jede KR richtet der Verbeißen-Angriff+1 TP an (in der ersten KR noch keinen zusätzlichen TP, in der 2. KR+1TP, in der 3. KR+2 TP usw.). Die TP werden wie üblich ausgewürfelt. Der Gegner erhält den Status Fixiert. Die Verteidigung des Molches sinkt, während er beißt, auf 0. Der Krakenmolch kann am Ende einer KR entscheiden loszulassen. Dieser Angriff ist um 2 erschwert.)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "• Klammergriff (Fangarm, kann der Gegner sich nicht erfolgreich verteidigen, hält der Krakenmolch ihn fest. Solange der Gegner festgehalten wird, leidet er unter den Status Fixiert und Eingeengt. Ab der nächsten KR muss der Krakenmolch keine AT mehr würfeln, sondern erzeugt durch Quetschen SP in Höhe der ausgewürfelten TP des Angriffs. Alternativ kann das Wesen 1 Aktion aufwenden, um das Opfer zu seinem Maul zu heben. In der folgenden KR kann er dann zubeißen. Diese Attacke gelingt automatisch. Die Verteidigung des Angreifers sinkt während des Rests der KR, in der der Biss stattfindet, auf 0. Der Klammergriff kann nur gegen Gegner kleinerer Größenkategorien verwendet werden. Um sich aus dem Klammergriff zu lösen, ist eine gelungene Vergleichsprobe auf Kraftakt (Ziehen & Zerren) nötig. Der Haltegriff kann nur gegen Gegner kleinerer Größenkategorien verwendet werden. Mittels einer freien Aktion kann der Krakenmolch den Gehaltenen loslassen. Sollte der Krakenmolch sein Opfer angehoben haben, erleidet es daraufhin den Status Liegend, sofern ihm nicht eine Probe auf Körperbeherrschung (Kampfmanöver) gelingt.) • Mächtiger Schlag (Fangarm, bei erfolgreichem Angriff müssen Gegner der Größenkategorie mittel und kleiner eine Probe auf Kraftakt erschwert um 8 bestehen, sofern sie nicht ausgewichen sind, ansonsten erhalten sie den Status Liegend) • Tentakelschwung (Fangarm, ist der Krakenmolch mindestens eine Größenkategorie größer als seine Ziele, kann er mit einem Tentakelschwung mehrere Ziele zu Fall bringen. Gegen diesen Angriff kann man nur ausweichen. Ist die Verteidigung misslungen, stürzt der Gegner und erleidet den Status Liegend. Durch den Fall erleidet man 1W3 SP. Ein solcher Angriff kann nur gegen Ziele neben oder vor dem angreifenden Wesen ausgeführt werden. Die Attacke ist um 2 pro Ziel erschwert.) • Verbeißen (Biss, der Krakenmolch führt einen Biss-Angriff aus. Kann der gelungene Angriff nicht verteidigt werden, so hat er sich festgebissen. In den nachfolgenden KR gelingt die Biss-Attacke automatisch, ohne dass der Meister würfeln muss. Jede KR richtet der Verbeißen-Angriff+1 TP an (in der ersten KR noch keinen zusätzlichen TP, in der 2. KR+1TP, in der 3. KR+2 TP usw.). Die TP werden wie üblich ausgewürfelt. Der Gegner erhält den Status Fixiert. Die Verteidigung des Molches sinkt, während er beißt, auf 0. Der Krakenmolch kann am Ende einer KR entscheiden loszulassen. Dieser Angriff ist um 2 erschwert.)"
+
+## Eisigel
+
+### Parser Warnings
+- advantages: Abschnitt "advantages" nicht gefunden.
+- disadvantages: Abschnitt "disadvantages" nicht gefunden.
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Parser] advantages: Abschnitt "advantages" nicht gefunden.
+- [Parser] disadvantages: Abschnitt "disadvantages" nicht gefunden.
+
+## Lyndereel Schmerzweber
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- equipment: Ausrüstungseintrag "Shakagra-Giftdolch" wurde als "Dolch" interpretiert (Schlüsselwort "dolch").
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] equipment: Ausrüstungseintrag "Shakagra-Giftdolch" wurde als "Dolch" interpretiert (Schlüsselwort "dolch").
+
+## Lynx
+
+### Parser Warnings
+- advantages: Abschnitt "advantages" nicht gefunden.
+- disadvantages: Abschnitt "disadvantages" nicht gefunden.
+
+### Resolver Warnings
+- specialAbilities: Eintrag "Verbeißen (Biss)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: Verbeißen (Biss)
+
+### Exporter Warnings
+- [Parser] advantages: Abschnitt "advantages" nicht gefunden.
+- [Parser] disadvantages: Abschnitt "disadvantages" nicht gefunden.
+- [Resolver] specialAbilities: Eintrag "Verbeißen (Biss)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "Verbeißen (Biss)"
+
+## Madalieb von Bilsbrück
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- specialAbilities: Eintrag "andere kann sie ob ihres Alters nicht mehr nutzen" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- languages: Eintrag "Oloargh I" konnte im Abschnitt languages nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: andere kann sie ob ihres Alters nicht mehr nutzen
+- **languages**: Oloargh I
+
+### Exporter Warnings
+- [Resolver] specialAbilities: Eintrag "andere kann sie ob ihres Alters nicht mehr nutzen" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] languages: Eintrag "Oloargh I" konnte im Abschnitt languages nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "andere kann sie ob ihres Alters nicht mehr nutzen"
+- [Resolver] languages: unverarbeitet "Oloargh I"
+
+## Soldat des Kaiser-Gerbald-Regiments
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Dhar’ylil Tanzt-im-Blut
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- equipment: Ausrüstungseintrag "Leichte Shakagra-Platte" wurde als "Plattenrüstung" interpretiert (Schlüsselwort "platte").
+- equipment: Ausrüstungseintrag "Shakagra-Krummsäbel" wurde als "Säbel" interpretiert (Schlüsselwort "krummsabel").
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] equipment: Ausrüstungseintrag "Leichte Shakagra-Platte" wurde als "Plattenrüstung" interpretiert (Schlüsselwort "platte").
+- [Resolver] equipment: Ausrüstungseintrag "Shakagra-Krummsäbel" wurde als "Säbel" interpretiert (Schlüsselwort "krummsabel").
+
+## Zorkarash Eisgänger
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- equipment: Ausrüstungseintrag "Leichte Shakagra-Platte" wurde als "Plattenrüstung" interpretiert (Schlüsselwort "platte").
+- equipment: Ausrüstungseintrag "Shakagra-Langschild" wurde als "Großschild" interpretiert (Schlüsselwort "langschild").
+- equipment: Ausrüstungseintrag "Shakagra-Hammer" wurde als "Hammer" interpretiert (Teilbegriff "Hammer").
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] equipment: Ausrüstungseintrag "Leichte Shakagra-Platte" wurde als "Plattenrüstung" interpretiert (Schlüsselwort "platte").
+- [Resolver] equipment: Ausrüstungseintrag "Shakagra-Langschild" wurde als "Großschild" interpretiert (Schlüsselwort "langschild").
+- [Resolver] equipment: Ausrüstungseintrag "Shakagra-Hammer" wurde als "Hammer" interpretiert (Teilbegriff "Hammer").
+
+## Skelettkrieger
+
+### Parser Warnings
+- talents: Talent konnte nicht interpretiert werden: "Schwimmen (keine Probe erlaubt; Skelette können nicht schwimmen)"
+- talents: Talent konnte nicht interpretiert werden: "Selbstbeherrschung - (gelingt automatisch)"
+- talents: Talent konnte nicht interpretiert werden: "Willenskraft - (gelingt automatisch)"
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Parser] talents: Talent konnte nicht interpretiert werden: "Schwimmen (keine Probe erlaubt; Skelette können nicht schwimmen)"
+- [Parser] talents: Talent konnte nicht interpretiert werden: "Selbstbeherrschung - (gelingt automatisch)"
+- [Parser] talents: Talent konnte nicht interpretiert werden: "Willenskraft - (gelingt automatisch)"
+
+## Kriegermumie
+
+### Parser Warnings
+- talents: Talent konnte nicht interpretiert werden: "Schwimmen (keine Probe erlaubt; Mumien können nicht schwimmen)"
+- talents: Talent konnte nicht interpretiert werden: "Selbstbeherrschung - (gelingt automatisch)"
+- talents: Talent konnte nicht interpretiert werden: "Willenskraft - (gelingt automatisch)"
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Parser] talents: Talent konnte nicht interpretiert werden: "Schwimmen (keine Probe erlaubt; Mumien können nicht schwimmen)"
+- [Parser] talents: Talent konnte nicht interpretiert werden: "Selbstbeherrschung - (gelingt automatisch)"
+- [Parser] talents: Talent konnte nicht interpretiert werden: "Willenskraft - (gelingt automatisch)"
+
+## Aswa-Djalihd
+
+### Parser Warnings
+- advantages: Abschnitt "advantages" nicht gefunden.
+- disadvantages: Abschnitt "disadvantages" nicht gefunden.
+- talents: Talent konnte nicht interpretiert werden: "Selbstbeherrschung - (gelingt automatisch)"
+
+### Resolver Warnings
+- specialAbilities: Eintrag "Mächtiger Schlag (Krallen)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: Mächtiger Schlag (Krallen)
+
+### Exporter Warnings
+- [Parser] advantages: Abschnitt "advantages" nicht gefunden.
+- [Parser] disadvantages: Abschnitt "disadvantages" nicht gefunden.
+- [Parser] talents: Talent konnte nicht interpretiert werden: "Selbstbeherrschung - (gelingt automatisch)"
+- [Resolver] specialAbilities: Eintrag "Mächtiger Schlag (Krallen)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "Mächtiger Schlag (Krallen)"
+
+## Shakagra-Klingensänger (erfahren / namhaft)
+
+### Parser Warnings
+- attributes: Eigenschaftszeilen nicht gefunden.
+- resources: LeP/AsP/KaP-Zeile nicht gefunden.
+
+### Resolver Warnings
+- specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- specialAbilities: Eintrag "Namhaft zusätzlich: Einhändiger Kampf" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- specialAbilities: Eintrag "Kampfeflexe II" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- talents: Eintrag "Erfahren: Einschüchtern" konnte im Abschnitt talents nicht aufgelöst werden.
+- spells: Eintrag "Erfahren: Attributo (Körperkraft)" konnte im Abschnitt spells nicht aufgelöst werden.
+- spells: Eintrag "Schlachtlied" konnte im Abschnitt spells nicht aufgelöst werden.
+- equipment: Eintrag "Bewaffnung wird ersetzt durch" konnte im Abschnitt equipment nicht aufgelöst werden.
+- armor: Eintrag "Leichte Shakagra-Platte" konnte im Abschnitt armor nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: Tradition (Nachtalben), Namhaft zusätzlich: Einhändiger Kampf, Kampfeflexe II
+- **talents**: Erfahren: Einschüchtern
+- **spells**: Erfahren: Attributo (Körperkraft), Schlachtlied
+- **equipment**: Bewaffnung wird ersetzt durch
+- **armor**: Leichte Shakagra-Platte
+
+### Exporter Warnings
+- [Parser] attributes: Eigenschaftszeilen nicht gefunden.
+- [Parser] resources: LeP/AsP/KaP-Zeile nicht gefunden.
+- [Resolver] specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] specialAbilities: Eintrag "Namhaft zusätzlich: Einhändiger Kampf" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] specialAbilities: Eintrag "Kampfeflexe II" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] talents: Eintrag "Erfahren: Einschüchtern" konnte im Abschnitt talents nicht aufgelöst werden.
+- [Resolver] spells: Eintrag "Erfahren: Attributo (Körperkraft)" konnte im Abschnitt spells nicht aufgelöst werden.
+- [Resolver] spells: Eintrag "Schlachtlied" konnte im Abschnitt spells nicht aufgelöst werden.
+- [Resolver] equipment: Eintrag "Bewaffnung wird ersetzt durch" konnte im Abschnitt equipment nicht aufgelöst werden.
+- [Resolver] armor: Eintrag "Leichte Shakagra-Platte" konnte im Abschnitt armor nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "Tradition (Nachtalben)"
+- [Resolver] specialAbilities: unverarbeitet "Namhaft zusätzlich: Einhändiger Kampf"
+- [Resolver] specialAbilities: unverarbeitet "Kampfeflexe II"
+- [Resolver] talents: unverarbeitet "Erfahren: Einschüchtern"
+- [Resolver] spells: unverarbeitet "Erfahren: Attributo (Körperkraft)"
+- [Resolver] spells: unverarbeitet "Schlachtlied"
+- [Resolver] equipment: unverarbeitet "Bewaffnung wird ersetzt durch"
+- [Resolver] armor: unverarbeitet "Leichte Shakagra-Platte"
+- [Exporter] armor: Rüstung "Leichte Shakagra-Platte" konnte nicht exportiert werden (keine Zuordnung).
+
+## Shakagra-Zauberweber (erfahren / namhaft)
+
+### Parser Warnings
+- attributes: Eigenschaftszeilen nicht gefunden.
+- resources: LeP/AsP/KaP-Zeile nicht gefunden.
+
+### Resolver Warnings
+- specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- talents: Eintrag "Erfahren: Einschüchtern" konnte im Abschnitt talents nicht aufgelöst werden.
+- spells: Eintrag "Erfahren: Dunkelheit" konnte im Abschnitt spells nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: Tradition (Nachtalben)
+- **talents**: Erfahren: Einschüchtern
+- **spells**: Erfahren: Dunkelheit
+
+### Exporter Warnings
+- [Parser] attributes: Eigenschaftszeilen nicht gefunden.
+- [Parser] resources: LeP/AsP/KaP-Zeile nicht gefunden.
+- [Resolver] specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] talents: Eintrag "Erfahren: Einschüchtern" konnte im Abschnitt talents nicht aufgelöst werden.
+- [Resolver] spells: Eintrag "Erfahren: Dunkelheit" konnte im Abschnitt spells nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "Tradition (Nachtalben)"
+- [Resolver] talents: unverarbeitet "Erfahren: Einschüchtern"
+- [Resolver] spells: unverarbeitet "Erfahren: Dunkelheit"
+
+## Zelot
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- spells: Eintrag "Schlachtlied" konnte im Abschnitt spells nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: Tradition (Nachtalben)
+- **spells**: Schlachtlied
+
+### Exporter Warnings
+- [Resolver] specialAbilities: Eintrag "Tradition (Nachtalben)" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] spells: Eintrag "Schlachtlied" konnte im Abschnitt spells nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "Tradition (Nachtalben)"
+- [Resolver] spells: unverarbeitet "Schlachtlied"
+
+## Spinnenwächter
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Eintrag "Mandibeln" konnte im Abschnitt weapons nicht aufgelöst werden.
+
+### Unresolved References
+- **weapons**: Mandibeln
+
+### Exporter Warnings
+- [Resolver] weapons: Eintrag "Mandibeln" konnte im Abschnitt weapons nicht aufgelöst werden.
+- [Resolver] weapons: unverarbeitet "Mandibeln"
+- [Exporter] weapons: Waffe "Mandibeln" konnte nicht exportiert werden (keine Zuordnung).
+
+## Scherenwächter
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Waffe "Scheren" wurde als "Schere" interpretiert (Teilbegriff "Schere").
+- weapons: Waffe "Scheren" enthält keine Kampftechnik im Datensatz.
+- weapons: Waffe "Shakagra-Kriegshammer" wurde als "Kriegshammer" interpretiert (Teilbegriff "Kriegshammer").
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- [Resolver] weapons: Waffe "Scheren" wurde als "Schere" interpretiert (Teilbegriff "Schere").
+- [Resolver] weapons: Waffe "Scheren" enthält keine Kampftechnik im Datensatz.
+- [Resolver] weapons: Waffe "Shakagra-Kriegshammer" wurde als "Kriegshammer" interpretiert (Teilbegriff "Kriegshammer").
+
+## Peitschender Wächter
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- weapons: Eintrag "Tentakel" konnte im Abschnitt weapons nicht aufgelöst werden.
+
+### Unresolved References
+- **weapons**: Tentakel
+
+### Exporter Warnings
+- [Resolver] weapons: Eintrag "Tentakel" konnte im Abschnitt weapons nicht aufgelöst werden.
+- [Resolver] weapons: unverarbeitet "Tentakel"
+- [Exporter] weapons: Waffe "Tentakel" konnte nicht exportiert werden (keine Zuordnung).
+
+## Späher
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- None
+
+### Unresolved References
+- None
+
+### Exporter Warnings
+- None
+
+## Eisharpyie
+
+### Parser Warnings
+- None
+
+### Resolver Warnings
+- specialAbilities: Eintrag "Flugangriff" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+
+### Unresolved References
+- **specialAbilities**: Flugangriff
+
+### Exporter Warnings
+- [Resolver] specialAbilities: Eintrag "Flugangriff" konnte im Abschnitt specialAbilities nicht aufgelöst werden.
+- [Resolver] specialAbilities: unverarbeitet "Flugangriff"
+

--- a/planning/work-items/done/optolith-equipment-extraction/story-exporter-cache-ui.md
+++ b/planning/work-items/done/optolith-equipment-extraction/story-exporter-cache-ui.md
@@ -10,10 +10,10 @@ As a converter maintainer I want resolved equipment to appear in the Optolith ex
 ## Acceptance Criteria
 | Criterion | Gherkin phrasing | Status |
 | --- | --- | --- |
-| AC1 | Given resolved equipment When the exporter runs Then weapons and armor populate the Optolith JSON `belongings` section | open |
-| AC2 | Given the cache controller saves conversions When schema version differs Then the controller clears or migrates entries to avoid stale structures | open |
-| AC3 | Given resolved warnings When the recent conversions list renders Then warning counts and breakdowns match the detailed list | open |
-| AC4 | (Optional) Given equipment data exists When the UI displays conversion results Then key equipment details are visible for validation | open |
+| AC1 | Given resolved equipment When the exporter runs Then weapons and armor populate the Optolith JSON `belongings` section | done |
+| AC2 | Given the cache controller saves conversions When schema version differs Then the controller clears or migrates entries to avoid stale structures | done |
+| AC3 | Given resolved warnings When the recent conversions list renders Then warning counts and breakdowns match the detailed list | done |
+| AC4 | (Optional) Given equipment data exists When the UI displays conversion results Then key equipment details are visible for validation | done |
 
 ## Dependencies
 - Parser and resolver equipment stories.
@@ -25,3 +25,4 @@ As a converter maintainer I want resolved equipment to appear in the Optolith ex
 - Prepare cache schema migration notes (documented in PR/README) and include helper to clear history with user-facing message.
 - Groomed 2025-10-22 (ref: `planning/runs/2025-10-22T12-00-00-weapon-armor-grooming/grooming-2025-10-22T12-00-00.md`).
 - Groomed 2025-10-22 (ref: `planning/runs/2025-10-22T12-00-00-weapon-armor-grooming/grooming-2025-10-22T12-00-00.md`).
+- QA sweep: `planning/runs/2025-10-16T12-00-00-dsa5-optolith-converter/sample-analysis-2025-11-06T08-27-27.md`.

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -114,7 +114,23 @@
         }
       },
       "normalizedHeading": "Normalisierter Statblock",
-      "jsonHeading": "Optolith-JSON-Vorschau",
+  "jsonHeading": "Optolith-JSON-Vorschau",
+  "result": {
+    "equipment": {
+      "heading": "Ausrüstungsübersicht",
+      "weapons": "Waffen",
+      "armor": "Rüstung",
+      "gear": "Weitere Ausrüstung",
+      "notLinked": "nicht verknüpft",
+      "noTechnique": "keine Kampftechnik",
+      "unarmed": "waffenlos",
+      "noProtection": "RS n/v",
+      "noEncumbrance": "BE n/v",
+      "protectionValue": "RS {value}",
+      "encumbranceValue": "BE {value}",
+      "unresolved": "nicht exportiert"
+    }
+  },
       "recent": {
         "title": "Zuletzt konvertiert",
         "empty": "Noch keine Konvertierungen gespeichert. Führe eine Konvertierung aus, um die Liste zu füllen.",
@@ -132,10 +148,11 @@
           "breakdown": "Parser: {parser}, Resolver: {resolver}, Exporter: {exporter}, Unaufgelöst: {unresolved}"
         },
         "storedAt": "Gespeichert am {date}",
-        "labels": {
-          "statBlock": "Statblock",
-          "json": "Gespeichertes JSON"
-        }
+    "labels": {
+      "statBlock": "Statblock",
+      "json": "Gespeichertes JSON",
+      "equipment": "Ausrüstungsübersicht"
+    }
       }
     },
     "about": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -114,7 +114,23 @@
         }
       },
       "normalizedHeading": "Normalized stat block",
-      "jsonHeading": "Optolith JSON preview",
+  "jsonHeading": "Optolith JSON preview",
+  "result": {
+    "equipment": {
+      "heading": "Equipment Summary",
+      "weapons": "Weapons",
+      "armor": "Armor",
+      "gear": "Other Equipment",
+      "notLinked": "not linked",
+      "noTechnique": "no technique",
+      "unarmed": "unarmed",
+      "noProtection": "RS n/a",
+      "noEncumbrance": "BE n/a",
+      "protectionValue": "RS {value}",
+      "encumbranceValue": "BE {value}",
+      "unresolved": "not exported"
+    }
+  },
       "recent": {
         "title": "Recent conversions",
         "empty": "No conversions cached yet. Run a conversion to populate this list.",
@@ -134,7 +150,8 @@
         "storedAt": "Saved {date}",
         "labels": {
           "statBlock": "Stat block",
-          "json": "Cached JSON"
+          "json": "Cached JSON",
+          "equipment": "Equipment Summary"
         }
       }
     },

--- a/src/types/optolith/converter.ts
+++ b/src/types/optolith/converter.ts
@@ -3,6 +3,34 @@ import type { OptolithDatasetManifest } from "../optolith/manifest";
 import type { ParserWarning } from "../optolith/stat-block";
 import type { ResolutionWarning } from "../../services/optolith/resolver";
 
+export interface EquipmentSummaryWeapon {
+  readonly name: string;
+  readonly templateId?: string;
+  readonly combatTechniqueId?: string;
+  readonly fallback?: "unarmed";
+  readonly unresolved?: boolean;
+}
+
+export interface EquipmentSummaryArmor {
+  readonly name: string;
+  readonly templateId?: string;
+  readonly protection?: number | null;
+  readonly encumbrance?: number | null;
+  readonly unresolved?: boolean;
+}
+
+export interface EquipmentSummaryItem {
+  readonly name: string;
+  readonly templateId?: string;
+  readonly unresolved?: boolean;
+}
+
+export interface EquipmentSummary {
+  readonly weapons: readonly EquipmentSummaryWeapon[];
+  readonly armor: EquipmentSummaryArmor | null;
+  readonly gear: readonly EquipmentSummaryItem[];
+}
+
 export interface ConversionResultPayload {
   readonly exported: OptolithExport;
   readonly exportedWarnings: readonly string[];
@@ -11,6 +39,7 @@ export interface ConversionResultPayload {
   readonly parserWarnings: readonly ParserWarning[];
   readonly resolverWarnings: readonly ResolutionWarning[];
   readonly unresolved: Readonly<Record<string, readonly string[]>>;
+  readonly equipmentSummary: EquipmentSummary;
 }
 
 export interface ConversionRequestMessage {

--- a/src/views/OptolithConverterView.vue
+++ b/src/views/OptolithConverterView.vue
@@ -195,6 +195,116 @@
           </ul>
         </div>
 
+        <section v-if="hasEquipmentSummary" class="optolith-result__equipment">
+          <h3 class="optolith-result__equipment-title">
+            {{ t("views.optolithConverter.result.equipment.heading") }}
+          </h3>
+
+          <div class="optolith-equipment">
+            <div
+              v-if="equipmentSummary.weapons.length > 0"
+              class="optolith-equipment__group"
+            >
+              <h4 class="optolith-equipment__group-title">
+                {{ t("views.optolithConverter.result.equipment.weapons") }}
+              </h4>
+              <ul class="optolith-equipment__list">
+                <li
+                  v-for="(weapon, index) in equipmentSummary.weapons"
+                  :key="`weapon-${index}-${weapon.name}`"
+                  class="optolith-equipment__item"
+                >
+                  <span class="optolith-equipment__name">{{
+                    weapon.name
+                  }}</span>
+                  <div class="optolith-equipment__badges">
+                    <code class="optolith-equipment__badge">
+                      {{ displayTemplateId(weapon.templateId) }}
+                    </code>
+                    <code class="optolith-equipment__badge">
+                      {{ displayWeaponTechnique(weapon) }}
+                    </code>
+                    <span
+                      v-if="weapon.unresolved"
+                      class="optolith-equipment__badge optolith-equipment__badge--warning"
+                    >
+                      {{
+                        t("views.optolithConverter.result.equipment.unresolved")
+                      }}
+                    </span>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <div
+              v-if="equipmentSummary.armor"
+              class="optolith-equipment__group"
+            >
+              <h4 class="optolith-equipment__group-title">
+                {{ t("views.optolithConverter.result.equipment.armor") }}
+              </h4>
+              <ul class="optolith-equipment__list">
+                <li class="optolith-equipment__item">
+                  <span class="optolith-equipment__name">
+                    {{ equipmentSummary.armor.name }}
+                  </span>
+                  <div class="optolith-equipment__badges">
+                    <code class="optolith-equipment__badge">
+                      {{ displayTemplateId(equipmentSummary.armor.templateId) }}
+                    </code>
+                    <code class="optolith-equipment__badge">
+                      {{ displayArmorProtection(equipmentSummary.armor) }}
+                    </code>
+                    <code class="optolith-equipment__badge">
+                      {{ displayArmorEncumbrance(equipmentSummary.armor) }}
+                    </code>
+                    <span
+                      v-if="equipmentSummary.armor.unresolved"
+                      class="optolith-equipment__badge optolith-equipment__badge--warning"
+                    >
+                      {{
+                        t("views.optolithConverter.result.equipment.unresolved")
+                      }}
+                    </span>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <div
+              v-if="equipmentSummary.gear.length > 0"
+              class="optolith-equipment__group"
+            >
+              <h4 class="optolith-equipment__group-title">
+                {{ t("views.optolithConverter.result.equipment.gear") }}
+              </h4>
+              <ul class="optolith-equipment__list">
+                <li
+                  v-for="(gear, index) in equipmentSummary.gear"
+                  :key="`gear-${index}-${gear.name}`"
+                  class="optolith-equipment__item"
+                >
+                  <span class="optolith-equipment__name">{{ gear.name }}</span>
+                  <div class="optolith-equipment__badges">
+                    <code class="optolith-equipment__badge">
+                      {{ displayTemplateId(gear.templateId) }}
+                    </code>
+                    <span
+                      v-if="gear.unresolved"
+                      class="optolith-equipment__badge optolith-equipment__badge--warning"
+                    >
+                      {{
+                        t("views.optolithConverter.result.equipment.unresolved")
+                      }}
+                    </span>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
         <details class="optolith-details">
           <summary>
             {{ t("views.optolithConverter.normalizedHeading") }}
@@ -316,6 +426,142 @@
                   </h3>
                   <pre class="optolith-history__pre">{{ entry.json }}</pre>
                 </section>
+                <section
+                  v-if="entryHasEquipment(entry)"
+                  class="optolith-history__section"
+                >
+                  <h3 class="optolith-history__section-title">
+                    {{ t("views.optolithConverter.recent.labels.equipment") }}
+                  </h3>
+                  <div class="optolith-equipment optolith-equipment--compact">
+                    <div
+                      v-if="entry.equipmentSummary.weapons.length > 0"
+                      class="optolith-equipment__group"
+                    >
+                      <h4 class="optolith-equipment__group-title">
+                        {{
+                          t("views.optolithConverter.result.equipment.weapons")
+                        }}
+                      </h4>
+                      <ul class="optolith-equipment__list">
+                        <li
+                          v-for="(weapon, index) in entry.equipmentSummary
+                            .weapons"
+                          :key="`history-weapon-${entry.id}-${index}`"
+                          class="optolith-equipment__item"
+                        >
+                          <span class="optolith-equipment__name">
+                            {{ weapon.name }}
+                          </span>
+                          <div class="optolith-equipment__badges">
+                            <code class="optolith-equipment__badge">
+                              {{ displayTemplateId(weapon.templateId) }}
+                            </code>
+                            <code class="optolith-equipment__badge">
+                              {{ displayWeaponTechnique(weapon) }}
+                            </code>
+                            <span
+                              v-if="weapon.unresolved"
+                              class="optolith-equipment__badge optolith-equipment__badge--warning"
+                            >
+                              {{
+                                t(
+                                  "views.optolithConverter.result.equipment.unresolved",
+                                )
+                              }}
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div
+                      v-if="entry.equipmentSummary.armor"
+                      class="optolith-equipment__group"
+                    >
+                      <h4 class="optolith-equipment__group-title">
+                        {{
+                          t("views.optolithConverter.result.equipment.armor")
+                        }}
+                      </h4>
+                      <ul class="optolith-equipment__list">
+                        <li class="optolith-equipment__item">
+                          <span class="optolith-equipment__name">
+                            {{ entry.equipmentSummary.armor.name }}
+                          </span>
+                          <div class="optolith-equipment__badges">
+                            <code class="optolith-equipment__badge">
+                              {{
+                                displayTemplateId(
+                                  entry.equipmentSummary.armor.templateId,
+                                )
+                              }}
+                            </code>
+                            <code class="optolith-equipment__badge">
+                              {{
+                                displayArmorProtection(
+                                  entry.equipmentSummary.armor,
+                                )
+                              }}
+                            </code>
+                            <code class="optolith-equipment__badge">
+                              {{
+                                displayArmorEncumbrance(
+                                  entry.equipmentSummary.armor,
+                                )
+                              }}
+                            </code>
+                            <span
+                              v-if="entry.equipmentSummary.armor.unresolved"
+                              class="optolith-equipment__badge optolith-equipment__badge--warning"
+                            >
+                              {{
+                                t(
+                                  "views.optolithConverter.result.equipment.unresolved",
+                                )
+                              }}
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div
+                      v-if="entry.equipmentSummary.gear.length > 0"
+                      class="optolith-equipment__group"
+                    >
+                      <h4 class="optolith-equipment__group-title">
+                        {{ t("views.optolithConverter.result.equipment.gear") }}
+                      </h4>
+                      <ul class="optolith-equipment__list">
+                        <li
+                          v-for="(gear, index) in entry.equipmentSummary.gear"
+                          :key="`history-gear-${entry.id}-${index}`"
+                          class="optolith-equipment__item"
+                        >
+                          <span class="optolith-equipment__name">
+                            {{ gear.name }}
+                          </span>
+                          <div class="optolith-equipment__badges">
+                            <code class="optolith-equipment__badge">
+                              {{ displayTemplateId(gear.templateId) }}
+                            </code>
+                            <span
+                              v-if="gear.unresolved"
+                              class="optolith-equipment__badge optolith-equipment__badge--warning"
+                            >
+                              {{
+                                t(
+                                  "views.optolithConverter.result.equipment.unresolved",
+                                )
+                              }}
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </section>
               </div>
             </div>
           </li>
@@ -333,6 +579,9 @@ import type {
   ConversionRequestMessage,
   ConversionResultPayload,
   ConverterWorkerMessage,
+  EquipmentSummary,
+  EquipmentSummaryArmor,
+  EquipmentSummaryWeapon,
 } from "@/types/optolith/converter";
 import { conversionCache } from "@/services/optolith/conversionCache";
 import type {
@@ -381,6 +630,34 @@ const cacheDateFormatter = computed(
     }),
 );
 
+function createEmptyEquipmentSummary(): EquipmentSummary {
+  return {
+    weapons: [],
+    armor: null,
+    gear: [],
+  };
+}
+
+function normalizeEquipmentSummary(
+  summary?: EquipmentSummary,
+): EquipmentSummary {
+  return summary ?? createEmptyEquipmentSummary();
+}
+
+function hasSummary(summary: EquipmentSummary): boolean {
+  return (
+    summary.weapons.length > 0 ||
+    summary.gear.length > 0 ||
+    summary.armor !== null
+  );
+}
+
+const equipmentSummary = computed<EquipmentSummary>(() =>
+  normalizeEquipmentSummary(result.value?.equipmentSummary),
+);
+
+const hasEquipmentSummary = computed(() => hasSummary(equipmentSummary.value));
+
 interface CacheEntryViewModel {
   readonly id: string;
   readonly name: string;
@@ -389,6 +666,7 @@ interface CacheEntryViewModel {
   readonly statBlock: string;
   readonly json: string;
   readonly warningSummary: WarningSummary;
+  readonly equipmentSummary: EquipmentSummary;
 }
 
 const recentEntries = computed<CacheEntryViewModel[]>(() =>
@@ -400,6 +678,7 @@ const recentEntries = computed<CacheEntryViewModel[]>(() =>
     statBlock: entry.statBlock,
     json: JSON.stringify(entry.payload.exported, null, 2),
     warningSummary: entry.warningSummary,
+    equipmentSummary: normalizeEquipmentSummary(entry.payload.equipmentSummary),
   })),
 );
 
@@ -450,6 +729,42 @@ const displayWarnings = computed(() => {
   );
   return Array.from(warnings);
 });
+
+function displayTemplateId(templateId?: string): string {
+  return templateId ?? t("views.optolithConverter.result.equipment.notLinked");
+}
+
+function displayWeaponTechnique(weapon: EquipmentSummaryWeapon): string {
+  if (weapon.combatTechniqueId) {
+    return weapon.combatTechniqueId;
+  }
+  if (weapon.fallback === "unarmed") {
+    return t("views.optolithConverter.result.equipment.unarmed");
+  }
+  return t("views.optolithConverter.result.equipment.noTechnique");
+}
+
+function displayArmorProtection(armor: EquipmentSummaryArmor): string {
+  if (armor.protection == null) {
+    return t("views.optolithConverter.result.equipment.noProtection");
+  }
+  return t("views.optolithConverter.result.equipment.protectionValue", {
+    value: armor.protection,
+  });
+}
+
+function displayArmorEncumbrance(armor: EquipmentSummaryArmor): string {
+  if (armor.encumbrance == null) {
+    return t("views.optolithConverter.result.equipment.noEncumbrance");
+  }
+  return t("views.optolithConverter.result.equipment.encumbranceValue", {
+    value: armor.encumbrance,
+  });
+}
+
+function entryHasEquipment(entry: CacheEntryViewModel): boolean {
+  return hasSummary(entry.equipmentSummary);
+}
 
 function ensureWorker(): Worker {
   if (worker.value) {
@@ -1155,6 +1470,86 @@ onBeforeUnmount(() => {
     monospace;
   font-size: 0.84rem;
   line-height: 1.45;
+}
+
+.optolith-result__equipment {
+  border-top: 1px solid rgba(47, 36, 18, 0.16);
+  padding-top: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.optolith-result__equipment-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(47, 36, 18, 0.9);
+}
+
+.optolith-equipment {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.optolith-equipment__group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.optolith-equipment__group-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(47, 36, 18, 0.85);
+}
+
+.optolith-equipment__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.optolith-equipment__item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.optolith-equipment__name {
+  font-weight: 600;
+  color: rgba(47, 36, 18, 0.95);
+}
+
+.optolith-equipment__badges {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.optolith-equipment__badge {
+  display: inline-block;
+  background: rgba(47, 36, 18, 0.08);
+  color: rgba(47, 36, 18, 0.8);
+  border-radius: 0.25rem;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.75rem;
+  font-family: var(--aventuria-font-mono, "Fira Code", monospace);
+}
+
+.optolith-equipment__badge--warning {
+  background: rgba(179, 71, 62, 0.18);
+  color: #5a1d18;
+}
+
+.optolith-equipment--compact .optolith-equipment__group-title {
+  font-size: 0.9rem;
+}
+
+.optolith-equipment--compact .optolith-equipment__badge {
+  font-size: 0.7rem;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- populate weapons, armor, and general gear in the Optolith export belongings and flag skipped items with exporter warnings
- attach an equipment summary to conversion payloads and render it in the converter result plus the recent history tab
- bump the conversion cache schema to v2, purge legacy entries automatically, and update translations/tests/QA tooling for the new data

## Testing
- npm run lint
- npm run typecheck
- npm run test:unit
- npm run optolith:build
- node dist/scripts/scripts/optolith/qa-samples.js