### PR TITLE
feat: enhance optolith usage guidance

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,13 @@
 
 Curated highlights of the most significant feature drops. Minor fixes, copy tweaks, and build housekeeping are intentionally omitted so this document stays focused on capabilities that change what the app can do.
 
+## 0.4.1 — Optolith UX Polish (2025-11-07)
+
+- Seeded the converter textarea with a full “Horasische Hafenwache” sample stat block placeholder so first-time users immediately see the expected format without pasting anything.
+- Added clipboard success feedback for both the main JSON result and each cached history entry, making copy actions obvious in long sessions.
+- Updated the Roll20 callout to clarify that humanoid NSC stat blocks provide the best results and that FoundryVTT usage is possible but still untested.
+- Hardened the Optolith parser/resolver: weapon lines are detected anywhere in the stat block, explicit “Kampftechniken” ratings feed combat-tech inference, and script sections now map to SA_27 entries like Kusliker Zeichen alongside standard languages.
+
 ## 0.4.0 — Optolith Equipment & Techniques (2025-11-07)
 
 - Added a multi-line weapon/armor parser that understands hyphenated names, plural quantities, attribute abbreviations, and inline notes so exotic stat blocks (“Tauchspeer”, “Immanschläger, den er als Knüppel nutzt”, etc.) can be normalized without manual cleanup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aventuria-impromptu",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aventuria-impromptu",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "bootstrap": "^5.3.8",
         "vue": "^3.5.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aventuria-impromptu",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",

--- a/planning/work-items/backlog/dsa5-optolith-converter/story-optolith-copy-feedback.md
+++ b/planning/work-items/backlog/dsa5-optolith-converter/story-optolith-copy-feedback.md
@@ -1,0 +1,26 @@
+# Story OPT-Converter-UX — Clipboard Feedback & Guidance
+
+## Context
+- Feature area: Optolith Converter UX
+- Motivation: Reduce user confusion when copying JSON, clarify supported stat blocks, and highlight FoundryVTT possibilities.
+
+## Description
+As a product owner I want clearer affordances and usage guidance in the Optolith converter so users know when JSON copy actions succeeded, what kind of stat blocks work best, and how the output might be used beyond Optolith.
+
+## Acceptance Criteria
+| Criterion | Description | Status |
+| --- | --- | --- |
+| AC1 | After pressing the “Copy JSON” button, the UI provides immediate success feedback (e.g., toast, inline notice, or icon state change) so users know the clipboard action worked. | pending |
+| AC2 | The stat block textarea contains a localized sample stat block (invented but plausible, e.g., a “Horasische Hafenwache” with realistic MU/KL/IN values) by default to illustrate the expected formatting, rather than an empty placeholder string. | pending |
+| AC3 | The converter view shows guidance that the workflow is optimized for humanoid NSC stat blocks and that monster stat blocks may only partially convert (attributes/talents). | pending |
+| AC4 | Documentation/UI copy explains that the exported JSON may be usable in FoundryVTT but is currently untested. | pending |
+
+## Dependencies
+- Existing Optolith converter UI components and i18n strings.
+- Clipboard helper that already handles JSON copy actions.
+
+## Notes
+- Consider reusing the existing warning/info callout styles for the “humanoid NSC” guidance so it’s visible but unobtrusive.
+- For sample stat block content, craft an original yet plausible humanoid stat block (e.g., “Horasische Hafenwache”) that demonstrates multi-line weapons, RS/BE, and special abilities; include a clear button so users can start fresh.
+- Confirm the clipboard success feedback also works for history entries (recent conversions tab) since they share the same helper.
+- When mentioning FoundryVTT, be explicit that it’s untested to manage expectations.

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -69,7 +69,9 @@
       "roll20Note": {
         "prefix": "Das Hauptziel des Konverters ist ein Import für das DSA5-Charakterblatt auf ",
         "linkText": "Roll20.net",
-        "suffix": ", damit neue NSC dort schneller angelegt werden können."
+        "suffix": ", damit neue NSC dort schneller angelegt werden können.",
+        "humanoid": "Am zuverlässigsten funktioniert das Tool mit humanoiden NSC-Statblöcken, die auch in Optolith angelegt werden könnten – Monster-Statblöcke liefern meist nur Attribute und Talente, dürfen aber gerne ausprobiert werden.",
+        "foundry": "Der JSON-Export könnte sich eventuell auch für FoundryVTT eignen, wurde dort aber bislang nicht getestet."
       },
       "languageNote": "Dieses Werkzeug verarbeitet ausschließlich deutsche Statblöcke. Bitte passe andere Sprachen vor der Konvertierung an.",
       "bugReportNote": {
@@ -92,9 +94,9 @@
       },
       "input": {
         "label": "Statblock",
-        "placeholder": "Statblock hier einfügen",
         "help": "Maximale Länge {max} Zeichen. Aktuell: {current}.",
-        "tooLong": "Der Statblock überschreitet die unterstützte Länge."
+        "tooLong": "Der Statblock überschreitet die unterstützte Länge.",
+        "sample": "Horasische Hafenwache\nMU 13 KL 11 IN 12 CH 10\nFF 11 GE 13 KO 12 KK 13\nLeP 34 AsP – KaP – INI 13+1W6\nAW 7 SK 2 ZK 2 GS 7\nWaffenlos: AT 14 PA 10 TP 1W6 RW kurz\nSäbel: AT 15 PA 11 TP 1W6+2 RW mittel\nArmbrust: FK 13 LZ 13 TP 1W6+6 RW 30/150/300\nRS/BE: 3/2 (Kettenhemd, Lederarmschienen)\nVorteile/Nachteile: Pflichtbewusstsein 6, Schlechte Eigenschaft (Arroganz)\nSonderfertigkeiten: Finte I (Säbel), Wuchtschlag I (Säbel), Aufmerksamkeit\nTalente: Einschüchtern 8, Körperbeherrschung 9, Menschenkenntnis 8, Selbstbeherrschung 8, Sinnesschärfe 9, Überreden 7, Verbergen 6\nKampfverhalten: Patrouilliert den Hafen und greift Eindringlinge mit Säbel und Armbrust an.\nFlucht: Verlust von 50 % der LeP\nSchmerz +1 bei: 26 LeP, 17 LeP, 9 LeP, 5 LeP oder weniger"
       },
       "buttons": {
         "convert": "Statblock konvertieren",
@@ -104,6 +106,7 @@
         "copyWarnings": "Warnungen kopieren",
         "copyJson": "JSON kopieren"
       },
+      "copySuccess": "In Zwischenablage kopiert",
       "loading": "Konvertierung läuft … bitte warten.",
       "datasetInfo": "Datensatzschema {schema} · Quellen-Prüfsumme {checksum}…",
       "warnings": {
@@ -144,7 +147,7 @@
       "intro": "Hintergründe zur Aventuria-Toolbox und der aktuellen Build-Version.",
       "body": {
         "paragraph1": "Aventuria Impromptu ist ein schlanker Werkzeugkasten für Spielleitungen in Aventurien. Die Tabellen basieren auf klassischen Zufallswürfen und liefern dir stimmige Ergebnisse für improvisierte Szenen.",
-        "paragraph2": "Die Anwendung ist bewusst leichtgewichtig gehalten: keine Server-Abhängigkeiten, nur Vue 3, Vite und ein Hauch Bootstrap."
+        "paragraph2": "Die Anwendung ist bewusst leichtgewichtig gehalten: keine Server-Abhängigkeiten, nur Vue 3, Vite und ein Hauch Bootstrap. Alles läuft lokal im Browser, es werden keine Daten übertragen und es gibt weder Konten noch Tracking oder Telemetrie."
       },
       "releaseNotesTitle": "Release Notes"
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -69,7 +69,9 @@
       "roll20Note": {
         "prefix": "The converter’s main purpose is to produce an import file for the DSA5 character sheet on ",
         "linkText": "Roll20.net",
-        "suffix": " so you can spin up NPCs there faster."
+        "suffix": " so you can spin up NPCs there faster.",
+        "humanoid": "It works best with humanoid NPC stat blocks that could exist in Optolith; monsters usually only yield attributes and talents but you are welcome to try.",
+        "foundry": "The JSON export might also be reusable in FoundryVTT, but that path is currently untested."
       },
       "languageNote": "Only German stat blocks are supported. Adjust the source material before converting other languages.",
       "bugReportNote": {
@@ -92,9 +94,9 @@
       },
       "input": {
         "label": "Stat block",
-        "placeholder": "Paste the stat block here",
         "help": "Maximum length {max} characters. Current: {current}.",
-        "tooLong": "The stat block exceeds the supported length."
+        "tooLong": "The stat block exceeds the supported length.",
+        "sample": "Horasische Hafenwache\nMU 13 KL 11 IN 12 CH 10\nFF 11 GE 13 KO 12 KK 13\nLeP 34 AsP – KaP – INI 13+1W6\nAW 7 SK 2 ZK 2 GS 7\nWaffenlos: AT 14 PA 10 TP 1W6 RW kurz\nSäbel: AT 15 PA 11 TP 1W6+2 RW mittel\nArmbrust: FK 13 LZ 13 TP 1W6+6 RW 30/150/300\nRS/BE: 3/2 (Kettenhemd, Lederarmschienen)\nVorteile/Nachteile: Pflichtbewusstsein 6, Schlechte Eigenschaft (Arroganz)\nSonderfertigkeiten: Finte I (Säbel), Wuchtschlag I (Säbel), Aufmerksamkeit\nTalente: Einschüchtern 8, Körperbeherrschung 9, Menschenkenntnis 8, Selbstbeherrschung 8, Sinnesschärfe 9, Überreden 7, Verbergen 6\nKampfverhalten: Patrouilliert den Hafen und greift Eindringlinge mit Säbel und Armbrust an.\nFlucht: Verlust von 50 % der LeP\nSchmerz +1 bei: 26 LeP, 17 LeP, 9 LeP, 5 LeP oder weniger"
       },
       "buttons": {
         "convert": "Convert Stat Block",
@@ -104,6 +106,7 @@
         "copyWarnings": "Copy warnings",
         "copyJson": "Copy JSON"
       },
+      "copySuccess": "Copied to clipboard",
       "loading": "Converting… please wait.",
       "datasetInfo": "Dataset schema {schema} · Source checksum {checksum}…",
       "warnings": {
@@ -144,7 +147,7 @@
       "intro": "Details about the Aventuria toolbox and the current build version.",
       "body": {
         "paragraph1": "Aventuria Impromptu is a lean toolkit for GMs in Aventuria. The tables rely on classic random rolls and deliver flavourful results for improvised scenes.",
-        "paragraph2": "The app stays deliberately lightweight: no servers, just Vue 3, Vite, and a touch of Bootstrap."
+        "paragraph2": "The app stays deliberately lightweight: no servers, just Vue 3, Vite, and a touch of Bootstrap. Everything runs entirely in your browser, no data leaves your device, and there is no account, tracking, telemetry, or analytics involved."
       },
       "releaseNotesTitle": "Release Notes"
     }

--- a/src/services/optolith/__tests__/exporter.spec.ts
+++ b/src/services/optolith/__tests__/exporter.spec.ts
@@ -123,4 +123,34 @@ Vorteile/Nachteile: Schlechte Eigenschaft (Goldgier)`;
       CT_12: 14,
     });
   });
+
+  it("uses manual combat technique entries when available", async () => {
+    const dataset = await loadDataset();
+    const lookups = createDatasetLookups(dataset);
+    const raw = `Test-Borscher
+MU 12 KL 10 IN 11 CH 9
+FF 10 GE 12 KO 11 KK 12
+LeP 30 AsP - KaP - INI 12+1W6
+AW 6 SK 1 ZK 1 GS 7
+Kampftechniken: Hiebwaffen 14, Raufen 12
+Vorteile: keine
+Nachteile: keine
+Sonderfertigkeiten: keine
+Talente: Klettern 5
+`;
+
+    const parsed = parseStatBlock(raw);
+    const resolved = resolveStatBlock(parsed.model, lookups);
+
+    const { hero } = exportToOptolithCharacter({
+      dataset: lookups,
+      parsed,
+      resolved,
+    });
+
+    expect(hero.ct).toMatchObject({
+      CT_5: 14,
+      CT_9: 12,
+    });
+  });
 });

--- a/src/services/optolith/__tests__/resolver.spec.ts
+++ b/src/services/optolith/__tests__/resolver.spec.ts
@@ -24,6 +24,8 @@ function createStatBlock(overrides: Partial<ParsedStatBlock>): ParsedStatBlock {
     attributes: {},
     pools: {},
     weapons: [],
+    combatTechniques: [],
+    scripts: [],
     advantages: [],
     disadvantages: [],
     specialAbilities: [],

--- a/src/services/optolith/__tests__/statBlockParser.spec.ts
+++ b/src/services/optolith/__tests__/statBlockParser.spec.ts
@@ -216,4 +216,30 @@ Ausrüstung: Immanschläger, den er als Knüppel nutzt, drei Speere, vier Wurfke
       "Persönlichkeitsschwäche (Vorurteile gegen Nichtzwölfgöttergläubige)",
     );
   });
+
+  it("captures combat technique ratings when present", () => {
+    const raw = `Arn Knokenbreeker
+MU 13 KL 9 IN 13 CH 13
+FF 12 GE 15 KO 14 KK 16
+LeP 40 SK 1 AsP – ZK 3
+KaP – AW 7 GS 8 INI 14+1W6
+Schriften: Kusliker Zeichen
+Kampftechniken: Hiebwaffen 14, Raufen 14
+Waffenlos: AT 15 PA 9 TP 1W6+2 RW kurz
+Knüppel: AT 15 PA 7 TP 1W6+4 RW mittel
+RS/BE 0/ 0
+Vorteile: Zäher Hund
+Nachteile: Schlechte Eigenschaft (Jähzorn)
+Talente: Körperbeherrschung 11, Kraftakt 13`;
+
+    const result = parseStatBlock(raw);
+
+    expect(result.model.combatTechniques).toEqual(
+      expect.arrayContaining([
+        { name: "Hiebwaffen", value: 14 },
+        { name: "Raufen", value: 14 },
+      ]),
+    );
+    expect(result.model.scripts).toContain("Kusliker Zeichen");
+  });
 });

--- a/src/services/optolith/combatTechniques.ts
+++ b/src/services/optolith/combatTechniques.ts
@@ -1,6 +1,7 @@
 import type { OptolithDatasetLookups } from "./dataset";
 import type { ResolutionResult, ResolvedWeapon } from "./resolver";
 import type { ParseResult } from "../../types/optolith/stat-block";
+import { normalizeLabel } from "../../utils/optolith/normalizer";
 
 interface EquipmentBaseSpecial {
   readonly combatTechnique?: string;
@@ -165,6 +166,21 @@ export function deriveCombatTechniques(
       fallback: weapon.fallback,
     });
     registerValue(ctId, ctName, derived, weapon.source.name);
+  }
+
+  for (const entry of parsed.model.combatTechniques ?? []) {
+    const normalized = normalizeLabel(entry.name);
+    if (!normalized) {
+      continue;
+    }
+    const ct = lookups.combatTechniques.byName.get(normalized);
+    if (!ct) {
+      warnings.push(
+        `[Exporter] combatTechniques: Kampftechnik "${entry.name}" konnte nicht aufgelöst werden.`,
+      );
+      continue;
+    }
+    registerValue(ct.id, ct.name, entry.value, entry.name);
   }
 
   return {

--- a/src/services/optolith/exporter.ts
+++ b/src/services/optolith/exporter.ts
@@ -313,6 +313,25 @@ function buildActivatable(
     addInstance(language.match.id, instance);
   });
 
+  resolved.scripts?.forEach((script) => {
+    if (!script.match) {
+      return;
+    }
+    const instance: Record<string, unknown> = {};
+    if (script.option) {
+      instance.sid = script.option.optionId;
+    }
+    if (!script.option && script.rawOption?.trim()) {
+      instance.options = [
+        {
+          type: "Custom",
+          value: script.rawOption.trim(),
+        },
+      ];
+    }
+    addInstance(script.match.id, instance);
+  });
+
   return entries;
 }
 

--- a/src/types/optolith/stat-block.ts
+++ b/src/types/optolith/stat-block.ts
@@ -67,11 +67,13 @@ export interface ParsedStatBlock {
   readonly armor?: ArmorStats | null;
   readonly actions?: number | null;
   readonly weapons: readonly WeaponStats[];
+  readonly combatTechniques: readonly RatedEntry[];
   readonly advantages: readonly string[];
   readonly disadvantages: readonly string[];
   readonly specialAbilities: readonly string[];
   readonly combatSpecialAbilities: readonly string[];
   readonly languages: readonly string[];
+  readonly scripts: readonly string[];
   readonly spells: readonly RatedEntry[];
   readonly liturgies: readonly RatedEntry[];
   readonly rituals: readonly RatedEntry[];


### PR DESCRIPTION
## Summary
- preload the Optolith converter with a sample "Horasische Hafenwache" stat block and add guidance about humanoid NSCs and FoundryVTT
- surface clipboard success feedback for the main result JSON and cached history entries
- capture backlog story OPT-Converter-UX so the UX improvements stay tracked in planning

## Testing
- npm run lint
- npm run typecheck
- npm run test:unit
- npm run optolith:build